### PR TITLE
Add deafen excludes

### DIFF
--- a/dozer/__main__.py
+++ b/dozer/__main__.py
@@ -49,6 +49,7 @@ config = {
     'is_backup': False,
     'invite_override': "",
     "sentry_url": "",
+    "deafen_excluded_channels_and_categories": [],
     "disabled_cogs": []
 }
 config_file = 'config.json'

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -152,7 +152,7 @@ class Moderation(Cog):
         # For some reason guild.me is returning None only sometimes, so this is a workaround to get perm_overrides working
         me = await guild.fetch_member(self.bot.user.id)
         for channel in channels:
-            if exclude_readonly and (channel.id in self.bot.config['deafen_excluded_channels_and_categories'] or channel.category.id in self.bot.config['deafen_excluded_channels_and_categories']):
+            if exclude_readonly and (channel.id in self.bot.config['deafen_excluded_channels_and_categories'] or channel.category in self.bot.config['deafen_excluded_channels_and_categories']):
                 logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because either the channel was excluded from deafen ({channel.id in self.bot.config['deafen_excluded_channels_and_categories']}) or it was part of an excluded category ({channel.category.id in self.bot.config['deafen_excluded_channels_and_categories']})")
                 continue
             overwrite = channel.overwrites_for(member)

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -154,10 +154,13 @@ class Moderation(Cog):
         for channel in channels:
             logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. Is TextChannel? {isinstance(channel, discord.TextChannel)} Is voice channel? {isinstance(channel, discord.VoiceChannel)} Is category channel? {isinstance(channel, discord.CategoryChannel)}")
             if exclude_readonly:
-                if channel.id in self.bot.config['deafen_excluded_channels_and_categories']: #or channel.category in self.bot.config['deafen_excluded_channels_and_categories']):
+                if channel.id in self.bot.config['deafen_excluded_channels_and_categories']:
                     logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel was directly excluded from deafen")
                     continue
                 elif channel is not isinstance(channel, discord.CategoryChannel):
+                    if channel.id in self.bot.config['deafen_excluded_channels_and_categories']:
+                        logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel was directly excluded from deafen (inner)")
+                        continue
                     if channel.category_id in self.bot.config['deafen_excluded_channels_and_categories']:
                         logger.debug (f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel was in an excluded category")
                         continue

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -152,8 +152,8 @@ class Moderation(Cog):
         # For some reason guild.me is returning None only sometimes, so this is a workaround to get perm_overrides working
         me = await guild.fetch_member(self.bot.user.id)
         for channel in channels:
-            logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. exclude_readonly is currently set {exclude_readonly}.")
-            if exclude_readonly and (channel.id in self.bot.config['deafen_excluded_channels_and_categories'] or channel.category in self.bot.config['deafen_excluded_channels_and_categories']):
+            logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. Is TextChannel? {isinstance(channel, discord.TextChannel)} Is voice channel? {isinstance(channel, discord.VoiceChannel)} Is category channel? {isinstance(channel, discord.CategoryChannel)}")
+            if exclude_readonly and ((channel.id in self.bot.config['deafen_excluded_channels_and_categories'] )or channel.category in self.bot.config['deafen_excluded_channels_and_categories']):
                 logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because either the channel was excluded from deafen ({channel.id in self.bot.config['deafen_excluded_channels_and_categories']}) or it was part of an excluded category ({channel.category in self.bot.config['deafen_excluded_channels_and_categories']})")
                 continue
             overwrite = channel.overwrites_for(member)

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -154,7 +154,7 @@ class Moderation(Cog):
         for channel in channels:
             if exclude_readonly:
                 logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. Is Text Channel? {isinstance(channel, discord.TextChannel)} Is voice channel? {isinstance(channel, discord.VoiceChannel)} Is category channel? {isinstance(channel, discord.CategoryChannel)}")
-                if channel is isinstance(channel, discord.CategoryChannel):
+                if isinstance(channel, discord.CategoryChannel):
                     #Skip overriding categories themselves. I am not convinced that there is a legitimate case that the category itself needs to be overridden. 
                     #All the voice, forum & text channels will also be overridden individually, and overriding categories can only cause conflicts when trying to exclude channels from being hidden in a deafen.
                     logger.debug(f"Skipping category override {channel} ({channel.id})")

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -153,17 +153,20 @@ class Moderation(Cog):
         me = await guild.fetch_member(self.bot.user.id)
         for channel in channels:
             if exclude_readonly:
+                logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. Is Text Channel? {isinstance(channel, discord.TextChannel)} Is voice channel? {isinstance(channel, discord.VoiceChannel)} Is category channel? {isinstance(channel, discord.CategoryChannel)}")
                 if channel is isinstance(channel, discord.CategoryChannel):
                     #Skip overriding categories themselves. I am not convinced that there is a legitimate case that the category itself needs to be overridden. 
                     #All the voice, forum & text channels will also be overridden individually, and overriding categories can only cause conflicts when trying to exclude channels from being hidden in a deafen.
+                    logger.debug(f"Skipping category override {channel} ({channel.id})")
                     continue
                 else:
                     if channel.id in self.bot.config['deafen_excluded_channels_and_categories']:
-                        logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel is directly excluded from deafen (inner)")
+                        logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel is directly excluded from deafen")
                         continue
                     if channel.category_id in self.bot.config['deafen_excluded_channels_and_categories']:
                         logger.debug (f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel is in an excluded category")
                         continue
+                logger.debug(f"Continuing with permission override on {channel} ({channel.id}) for {member} ({member.id}) ")
             overwrite = channel.overwrites_for(member)
             if channel.permissions_for(me).manage_roles:
                 overwrite.update(**overwrites)

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -152,8 +152,9 @@ class Moderation(Cog):
         # For some reason guild.me is returning None only sometimes, so this is a workaround to get perm_overrides working
         me = await guild.fetch_member(self.bot.user.id)
         for channel in channels:
+            logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. exclude_readonly is currently set {exclude_readonly}.")
             if exclude_readonly and (channel.id in self.bot.config['deafen_excluded_channels_and_categories'] or channel.category in self.bot.config['deafen_excluded_channels_and_categories']):
-                logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because either the channel was excluded from deafen ({channel.id in self.bot.config['deafen_excluded_channels_and_categories']}) or it was part of an excluded category ({channel.category.id in self.bot.config['deafen_excluded_channels_and_categories']})")
+                logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because either the channel was excluded from deafen ({channel.id in self.bot.config['deafen_excluded_channels_and_categories']}) or it was part of an excluded category ({channel.category in self.bot.config['deafen_excluded_channels_and_categories']})")
                 continue
             overwrite = channel.overwrites_for(member)
             if channel.permissions_for(me).manage_roles:

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -153,9 +153,14 @@ class Moderation(Cog):
         me = await guild.fetch_member(self.bot.user.id)
         for channel in channels:
             logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. Is TextChannel? {isinstance(channel, discord.TextChannel)} Is voice channel? {isinstance(channel, discord.VoiceChannel)} Is category channel? {isinstance(channel, discord.CategoryChannel)}")
-            if exclude_readonly and ((channel.id in self.bot.config['deafen_excluded_channels_and_categories'] )or channel.category in self.bot.config['deafen_excluded_channels_and_categories']):
-                logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because either the channel was excluded from deafen ({channel.id in self.bot.config['deafen_excluded_channels_and_categories']}) or it was part of an excluded category ({channel.category in self.bot.config['deafen_excluded_channels_and_categories']})")
-                continue
+            if exclude_readonly:
+                if channel.id in self.bot.config['deafen_excluded_channels_and_categories']: #or channel.category in self.bot.config['deafen_excluded_channels_and_categories']):
+                    logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel was directly excluded from deafen")
+                    continue
+                elif channel is not isinstance(channel, discord.CategoryChannel):
+                    if channel.category_id in self.bot.config['deafen_excluded_channels_and_categories']:
+                        logger.debug (f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel was in an excluded category")
+                        continue
             overwrite = channel.overwrites_for(member)
             if channel.permissions_for(me).manage_roles:
                 overwrite.update(**overwrites)

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -153,7 +153,6 @@ class Moderation(Cog):
         me = await guild.fetch_member(self.bot.user.id)
         for channel in channels:
             if exclude_readonly:
-                logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. Is Text Channel? {isinstance(channel, discord.TextChannel)} Is voice channel? {isinstance(channel, discord.VoiceChannel)} Is category channel? {isinstance(channel, discord.CategoryChannel)}")
                 if isinstance(channel, discord.CategoryChannel):
                     #Skip overriding categories themselves. I am not convinced that there is a legitimate case that the category itself needs to be overridden. 
                     #All the voice, forum & text channels will also be overridden individually, and overriding categories can only cause conflicts when trying to exclude channels from being hidden in a deafen.
@@ -166,7 +165,7 @@ class Moderation(Cog):
                     if channel.category_id in self.bot.config['deafen_excluded_channels_and_categories']:
                         logger.debug (f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel is in an excluded category")
                         continue
-                logger.debug(f"Continuing with permission override on {channel} ({channel.id}) for {member} ({member.id}) ")
+                logger.debug(f"Overriding on {channel} ({channel.id}) for {member} ({member.id})")
             overwrite = channel.overwrites_for(member)
             if channel.permissions_for(me).manage_roles:
                 overwrite.update(**overwrites)

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -152,17 +152,17 @@ class Moderation(Cog):
         # For some reason guild.me is returning None only sometimes, so this is a workaround to get perm_overrides working
         me = await guild.fetch_member(self.bot.user.id)
         for channel in channels:
-            logger.debug(f"Start of deafen logic. Current channel: {channel} ({channel.id}) which is a part of the category {channel.category}. Is TextChannel? {isinstance(channel, discord.TextChannel)} Is voice channel? {isinstance(channel, discord.VoiceChannel)} Is category channel? {isinstance(channel, discord.CategoryChannel)}")
             if exclude_readonly:
-                if channel.id in self.bot.config['deafen_excluded_channels_and_categories']:
-                    logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel was directly excluded from deafen")
+                if channel is isinstance(channel, discord.CategoryChannel):
+                    #Skip overriding categories themselves. I am not convinced that there is a legitimate case that the category itself needs to be overridden. 
+                    #All the voice, forum & text channels will also be overridden individually, and overriding categories can only cause conflicts when trying to exclude channels from being hidden in a deafen.
                     continue
-                elif channel is not isinstance(channel, discord.CategoryChannel):
+                else:
                     if channel.id in self.bot.config['deafen_excluded_channels_and_categories']:
-                        logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel was directly excluded from deafen (inner)")
+                        logger.debug(f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel is directly excluded from deafen (inner)")
                         continue
                     if channel.category_id in self.bot.config['deafen_excluded_channels_and_categories']:
-                        logger.debug (f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel was in an excluded category")
+                        logger.debug (f"Skipping {channel} ({channel.id}) override for {member} ({member.id}) because the channel is in an excluded category")
                         continue
             overwrite = channel.overwrites_for(member)
             if channel.permissions_for(me).manage_roles:


### PR DESCRIPTION
Adds a new bot config option that allows specified channel or category IDs to be excluded from deafen or selfdeafen operations. 

Changes:
-  Added a config.json option 'deafen_excluded_channels_and_categories'. This is blank by default, and channel or category IDs can be inserted here to be excluded from deafen (includes self-deafen).
- Added a new parameter, exclude_readonly, to the perm_override function. This is set to false by default for compatibility. It will cause the specified overrides to be skipped for all channels (or channels within categories) which are present in deafen_excluded_channels_and_categories.

Limitations:
- Running an override with exclude_readonly causes all category-level overrides to be skipped explicitly. This was done because discord.py seems to return a List via fetch_channels that is ordered based on creation date. This causes a race condition based on the order of channel/category creation in the server. If a channel is newer than the category it is part of, and is excluded in the config (but its parent category is not), it will erroneously be overridden because the category is returned before the individual channel. This is admittedly a crude solution and may have unexpected issues later, but I could not identify any immediate issues with this approach. Discord.py also individually returns all text, voice, forum, and stage channels, which would apply the overrides if the channel was not excluded.
- Having these values in the bot config is not the best way to manage this, and making a set of configuration commands and an associated database table to manage the values would be better.
- exclude_readonly is hardcoded to be True for all deafen and selfdeafen operations and False for all other operations. It may be desirable to have this be configurable, though I cannot think of another operation where this would be beneficial at current. Using a database table can make this behavior more flexible, i.e., differing sets of channels skip overrides for different moderation actions.